### PR TITLE
2.4 versions and compat

### DIFF
--- a/modules/concept-docs/pages/collections.adoc
+++ b/modules/concept-docs/pages/collections.adoc
@@ -3,12 +3,14 @@
 :page-topic-type: concept
 :nav-title: Collections
 
+include::project-docs:partial$attributes.adoc[]
+
 [abstract]
 {description}
 
-The Collections feature in Couchbase Server is fully implemented in the 2.3 API version of the Couchbase SDK.
+The Collections feature in Couchbase Server is fully implemented in the {go-current-version} API version of the Couchbase SDK.
 
-Information on _Collections_ can be found in the xref:7.0@server:learn:data:scopes-and-collections.adoc[server docs].
+Information on _Collections_ can be found in the xref:{version-server}@server:learn:data:scopes-and-collections.adoc[server docs].
 
 == Using Collections & Scopes
 

--- a/modules/concept-docs/pages/n1ql-query.adoc
+++ b/modules/concept-docs/pages/n1ql-query.adoc
@@ -4,16 +4,18 @@
 :page-topic-type: concept
 :page-aliases: ROOT:n1ql-query,
 
+include::project-docs:partial$attributes.adoc[]
+
 [abstract]
 {description}
 
-include::7.0@sdk:shared:partial$n1ql-queries.adoc[tag=intro]
+include::{version-server}@sdk:shared:partial$n1ql-queries.adoc[tag=intro]
 
 
 // Prepared Statements for Query Optimization
-include::7.0@sdk:shared:partial$n1ql-queries.adoc[tag=prepared]
+include::{version-server}@sdk:shared:partial$n1ql-queries.adoc[tag=prepared]
 
-NOTE: In Go SDK 2.3 and earlier, the `adhoc` parameter is `Adhoc`.
+NOTE: In Go SDK {go-current-version} and earlier, the `adhoc` parameter is `Adhoc`.
 It is set to `false` by default -- set to `true` for a plan _not_ to be prepared, or a prepared plan _not_ to be reused.
 The 5000 limit to the client-side cache also does not apply.
 
@@ -25,10 +27,10 @@ include::example$n1ql-query.go[tag=prepared-statement]
 
 == Indexes
 
-The Couchbase query service makes use of xref:7.0@server:learn:services-and-indexes/indexes/indexes.adoc[_indexes_] in order to do its work.
+The Couchbase query service makes use of xref:{version-server}@server:learn:services-and-indexes/indexes/indexes.adoc[_indexes_] in order to do its work.
 Indexes replicate subsets of documents from data nodes over to index nodes, 
 allowing specific data (for example, specific document properties) to be retrieved quickly, 
-and to distribute load away from data nodes in xref:7.0@server:learn:services-and-indexes/services/services.adoc[MDS] topologies.
+and to distribute load away from data nodes in xref:{version-server}@server:learn:services-and-indexes/services/services.adoc[MDS] topologies.
 
 [IMPORTANT]
 In order to make a bucket queryable, it must have at least one index defined.
@@ -63,7 +65,7 @@ Indexes help improve the performance of a query.
 When an index includes the actual values of all the fields specified in the query, 
 the index _covers_ the query, and eliminates the need to fetch the actual values from the Data Service.
 An index, in this case, is called a _covering index_, and the query is called a _covered_ query.
-For more information, see xref:7.0@server:n1ql:n1ql-language-reference/covering-indexes.adoc[Covering Indexes].
+For more information, see xref:{version-server}@server:n1ql:n1ql-language-reference/covering-indexes.adoc[Covering Indexes].
 
 You can also create and define indexes in the SDK using:
 
@@ -101,11 +103,11 @@ include::example$n1ql-query.go[tag=deferred-index]
 
 // == Index Consistency
 
-include::7.0@sdk:shared:partial$n1ql-queries.adoc[tag=index-consistency]
+include::{version-server}@sdk:shared:partial$n1ql-queries.adoc[tag=index-consistency]
 
 The following options are available:
 
-include::7.0@server:learn:page$services-and-indexes/indexes/index-replication.adoc[tag=scan_consistency]
+include::{version-server}@server:learn:page$services-and-indexes/indexes/index-replication.adoc[tag=scan_consistency]
 ////
 * `not_bounded`: Executes the query immediately, without requiring any consistency for the query.
 If index-maintenance is running behind, out-of-date results may be returned.

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -3,6 +3,8 @@
 :page-aliases: ROOT:getting-started,ROOT:start-using,ROOT:hello-couchbase,ROOT:start-using-sdk
 :navtitle: Start Using the SDK
 
+include::project-docs:partial$attributes.adoc[]
+
 [abstract]
 The Couchbase Go SDK allows you to connect to a Couchbase cluster from Go.
 It is a native Go library and uses the high-performance gocbcore to handle communicating to the cluster over Couchbase’s binary protocols
@@ -57,7 +59,7 @@ include::example$startusing.go[tag=bucket]
 If you installed the travel sample data bucket, replace _bucketName_ with _travel-sample_.
 
 
-The 2.3 SDK supports full integration with the xref:concept-docs:collections.adoc[Collections] feature in the latest release of the Couchbase Data Platform, Couchbase Server 7.0.
+The {go-current-version} SDK supports full integration with the xref:concept-docs:collections.adoc[Collections] feature in the latest release of the Couchbase Data Platform, Couchbase Server 7.0.
 This brings complete support of Collections, allowing Documents to be grouped by purpose or theme, according to a specified _Scope_.
 Here we will use the `users` collection within the `tenant_agent_00` scope from `travel-sample` bucket as an example.
 
@@ -82,7 +84,7 @@ Now that you know the basics, you may wish to go straight to that page.
 == Cloud Connections
 
 For developing on https://docs.couchbase.com/cloud/index.html[Couchbase Capella], 
-try the https://github.com/couchbase/docs-sdk-go/blob/release/2.3/modules/devguide/examples/go/cloud.go[Cloud-based Hello World program].
+try the https://github.com/couchbase/docs-sdk-go/blob/release/{go-current-version}/modules/devguide/examples/go/cloud.go[Cloud-based Hello World program].
 
 If you are not working from the same _Availability Zone_ as your Capella instance, refer to the following:
 

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -4,11 +4,13 @@
 :page-topic-type: howto
 :page-aliases: document-operations.adoc
 
+include::project-docs:partial$attributes.adoc[]
+
 [abstract]
 {description}
 Here we cover CRUD operations, document expiration, and optimistic locking with CAS.
 
-The complete code sample used on this page can be downloaded from https://github.com/couchbase/docs-sdk-go/blob/release/2.3/modules/devguide/examples/go/kv-crud.go[here]
+The complete code sample used on this page can be downloaded from https://github.com/couchbase/docs-sdk-go/blob/release/{go-current-version}/modules/devguide/examples/go/kv-crud.go[here]
 -- from which you can see in context how to authenticate and connect to a Couchbase Cluster, then perform these Collection operations.
 
 == Documents
@@ -62,7 +64,7 @@ include::devguide:example$go/kv-crud.go[tag=update]
 
 Expiry sets an explicit time to live (TTL) for a document in seconds.
 For a discussion of item (Document) _vs_ Bucket expiration, see the 
-xref:7.0@server:learn:buckets-memory-and-storage/expiration.adoc#expiration-bucket-versus-item[Expiration Overview page].
+xref:{version-server}@server:learn:buckets-memory-and-storage/expiration.adoc#expiration-bucket-versus-item[Expiration Overview page].
 
 [source,golang,indent=0]
 ----
@@ -75,7 +77,7 @@ Writes in Couchbase are written to a single node, and from there the Couchbase S
 The optional durability parameter, which all mutating operations accept, allows the application to wait until this replication (or persistence) is successful before proceeding.
 
 In Couchbase Server releases before 6.5, Durability was set with two options -- see the xref:1.6@go-sdk::durability.adoc[6.0 Durability documentation] -- covering how many replicas the operation must be propagated to and how many persisted copies of the modified record must exist. 
-Couchbase Data Platform 6.5 refines these two options, with xref:7.0@server:learn:data/durability.adoc[Durable Writes] -- although they remain essentially the same in use.
+Couchbase Data Platform 6.5 refines these two options, with xref:{version-server}@server:learn:data/durability.adoc[Durable Writes] -- although they remain essentially the same in use.
 The Go SDK exposes both of these forms of Durability.
 
 First we will cover the newer durability features available in Couchbase server 6.5 onwards.
@@ -193,7 +195,7 @@ NOTE: Increment & Decrement are considered part of the 'binary' API and as such 
 
 == Scoped KV Operations
 
-It is possible to perform scoped key-value operations on named xref:7.0@server:learn:data/scopes-and-collections.adoc[`Collections`] _with Couchbase Server release 7.0_.
+It is possible to perform scoped key-value operations on named xref:{version-server}@server:learn:data/scopes-and-collections.adoc[`Collections`] _with Couchbase Server release 7.0_.
 See the https://pkg.go.dev/github.com/couchbase/gocb/v2#Collection[API docs] for more information.
 
 Here is an example showing an upsert in the `users` collection, which lives in the `travel-sample.tenant_agent_00` keyspace:

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -4,10 +4,12 @@ Plus notes on Cloud, networks, and AWS Lambda.
 :navtitle: Compatibility
 :page-aliases: ROOT:overview,ROOT:compatibility-versions-features,compatibility-versions-features
 
+include::project-docs:partial$attributes.adoc[]
+
 [abstract]
 {description}
 
-Couchbase Go SDK 2.3 requires Go version 1.13, or later.
+Couchbase Go SDK {go-current-version} requires Go version 1.13, or later.
 In line with the https://golang.org/doc/devel/release.html#policy[Golang project], we support both the current, and the previous, versions of Go.
 
 == Couchbase Version/SDK Version Matrix
@@ -25,12 +27,7 @@ It is best to upgrade either the SDK or the Couchbase version you are using.
 [#table_sdk_versions]
 [cols="40,20,25,20"]
 |===
-| | SDK 1.6 | SDK 2.0 - 2.2 | 2.3
-
-| *Server 5.0-5.5*
-| *✔*
-| *◎*
-| *◎*
+| | SDK 1.6 | SDK 2.0 - 2.2 | 2.3, 2.4
 
 | *Server 6.0*
 | *✔*
@@ -55,37 +52,40 @@ See the notes there for Support details.
 
 .Couchbase Server and SDK Supported Version Matrix
 [.table-merge-cells] 
-[cols="7,7,5,6,5"]
+[cols="7,5,6,5"]
 |===
-| | Server 5.0, 5.1, & 5.5 | Server 6.0 | Server 6.5 & 6.6 | Server 7.0
+| | Server 6.0 | Server 6.5 & 6.6 | Server 7.0
 
 | Enhanced Durability
-4+| All SDK versions
+3+| All SDK versions
 
 | Durable Writes 
-2+| Not Supported
+1+| Not Supported
 2+| Since 2.0
 
 | Analytics
-| DP in 5.5 with 1.4
 3+| Since 1.5
 
 | Default Collections
-2+| Not Supported
+| Not Supported
 | Developer Preview in 6.5-6.6, SDK 2.0
 | Since 2.1.8
 
 | Scope-Level N1QL Queries & all Collections features
-3+| Not Supported
+2+| Not Supported
 | Since SDK 2.3.0
 
 | Field Level Encryption v2
-2+| Not Supported
+| Not Supported
 2+| Since SDK 2.3.0footnote:[Field Level Encryption distributed as separate library.]
 
 | Request Tracing
-2+| Not Supported
+| Not Supported
 2+| Since SDK 2.0.3 (stable interface from 2.3.0)
+
+| Distributed ACID Transactions
+2+| Not Supported
+| Since SDK 2.4.0
 |===
 
 

--- a/modules/project-docs/partials/attributes.adoc
+++ b/modules/project-docs/partials/attributes.adoc
@@ -1,4 +1,4 @@
 :go-api-link: http://docs.couchbase.com/sdk-api/couchbase-go-client-2.2.2
-:go-current-version: 2.3
+:go-current-version: 2.4
 :version-server: 7.0
 :name-sdk: Go SDK


### PR DESCRIPTION
* Updates any remaining mentions of 2.3 versions (using `go-current-version` param)
* Driveby updates for server version with `version-server` param
* Updates the compatibility and feature matrix table for 2.4