### PR TITLE
Update and move observability docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -33,9 +33,11 @@
 
 .Errors & Diagnostics
 * xref:howtos:error-handling.adoc[Handling Errors]
-** xref:howtos:slow-operations-logging.adoc[Slow Operations Logging]
 * xref:howtos:health-check.adoc[Health Check]
 * xref:howtos:collecting-information-and-logging.adoc[Collecting Information & Logging]
+* Observability
+** xref:howtos:slow-operations-logging.adoc[Slow Operations Logging]
+** xref:howtos:observability-orphan-logger.adoc[Orphan Requests Logging]
 
 .Learn
 * xref:concept-docs:concepts.adoc[Overview]

--- a/modules/devguide/examples/go/slow-operations.go
+++ b/modules/devguide/examples/go/slow-operations.go
@@ -23,3 +23,8 @@ func main() {
 	// #end::config[]
 	throwaway(opts)
 }
+
+// just used so that we can show creation of resources without the linter complaining.
+func throwaway(interface{}) {
+
+}

--- a/modules/devguide/examples/go/slow-operations.go
+++ b/modules/devguide/examples/go/slow-operations.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/couchbase/gocb/v2"
+	"time"
+)
+
+func main() {
+	// #tag::config[]
+	tracerOpts := &gocb.ThresholdLoggingOptions{
+		Interval:   10 * time.Second,
+		SampleSize: 10,
+	}
+	tracer := gocb.NewThresholdLoggingTracer(tracerOpts)
+
+	opts := gocb.ClusterOptions{
+		Authenticator: gocb.PasswordAuthenticator{
+			Username: "Administrator",
+			Password: "password",
+		},
+		Tracer: tracer,
+	}
+	// #end::config[]
+	throwaway(opts)
+}

--- a/modules/howtos/pages/observability-orphan-logger.adoc
+++ b/modules/howtos/pages/observability-orphan-logger.adoc
@@ -1,0 +1,91 @@
+= Orphaned Requests Logging
+:description: In addition to request tracing and metrics reporting, logging orphaned requests provides additional insight into why an operation might have timed out (or got cancelled for a different reason).
+:page-topic-type: howto
+
+[abstract]
+{description}
+
+While tracing and metrics can also be consumed through external interfaces, getting information about orphaned requests only works through the built-in mechanisms.
+
+The way it works is that every time a response is in the process of being completed, when the SDK detects that the original caller is not listening anymore (likely because of a timeout), it will send this "orphaned" response to a reporting utility which aggregates all responses and in regular intervals logs them in a specific format.
+
+When you spot an `ErrTimeout` in your log file, you can look for the output of the `OrphanReporter` and correlate the information.
+
+== Output Format
+
+The `OrphanReporter` detects orphaned requests and creates a log entry for each, which in turn are going to be logged alongside all other SDK logs.
+Since orphans usually indicate a state that is not desirable, the log level for those events is `WARN`.
+By default, they will be aggregated and logged every 10 seconds, but the event will be skipped if there are no orphans to report.
+This makes sure that the log line will appear close to the corresponding `ErrTimeout` in the logs, while not spamming the log file if there is nothing to report.
+See the next section on how to customize this behavior.
+In the Go SDK `OrphanReporter` is only applicable to the key value service, other services use HTTP which is a blocking operation and cannot create orphaned requests.
+
+The actual body of the message consists of the text `Orphaned responses observed`, followed by a compact JSON representation of the aggregated orphans.
+The following code snippet shows a prettified version of such a JSON blob:
+
+[source,json]
+----
+{
+  "kv": {
+    "total_count": 3,
+    "top_requests": [
+      {
+        "last_local_id": "6fc84f6b1e27f9ec/1264152ff6b5299a",
+        "operation_id": "0x7",
+        "last_remote_socket": "10.112.230.102:11210",
+        "last_local_socket": "10.112.230.1:63747",
+        "last_server_duration_us": 243,
+        "operation_name": "CMD_SET"
+      },
+      {
+        "last_local_id": "6fc84f6b1e27f9ec/1264152ff6b5299a",
+        "operation_id": "0x8",
+        "last_remote_socket": "10.112.230.102:11210",
+        "last_local_socket": "10.112.230.1:63747",
+        "last_server_duration_us": 300,
+        "operation_name": "CMD_SET"
+      },
+      {
+        "last_local_id": "6fc84f6b1e27f9ec/1264152ff6b5299a",
+        "operation_id": "0x9",
+        "last_remote_socket": "10.112.230.102:11210",
+        "last_local_socket": "10.112.230.1:63747",
+        "last_server_duration_us": 210,
+        "operation_name": "CMD_SET"
+      }
+    ]
+  }
+}
+----
+
+Please note that we do not provide any stability guarantees on the logging output format and it might change between minor versions.
+
+JSON Output Format Descriptions
+[options="header"]
+|====
+| Property       | Description
+| `last_server_duration_us` | The server duration, if present.
+| `operation_name` | The name of the operation.
+| `last_local_id` | The connection id.
+| `operation_id` | The operation id (this can be used to match up to logged requests using their `opaque` values).
+| `last_local_socket` | The local address, if present.
+| `last_remote_socket` | The remote address, if present.
+|====
+
+If a field is not available, it will not be included in the output.
+
+== Configuration
+
+The orphan logger can be configured through the `OrphanReporterConfig`.
+
+The following properties can be configured:
+
+.OrphanReporterConfig Properties
+[options="header"]
+|====
+| Property       | Default | Description
+| `EmitInterval` | 10 seconds | The interval where found orphans are emitted.
+| `SampleSize`   | 10 | The number of samples to store per service.
+| `Disabled`  | false | Whether to disable the `OrphanReporter`.
+|====
+

--- a/modules/howtos/pages/observability-orphan-logger.adoc
+++ b/modules/howtos/pages/observability-orphan-logger.adoc
@@ -18,7 +18,7 @@ Since orphans usually indicate a state that is not desirable, the log level for 
 By default, they will be aggregated and logged every 10 seconds, but the event will be skipped if there are no orphans to report.
 This makes sure that the log line will appear close to the corresponding `ErrTimeout` in the logs, while not spamming the log file if there is nothing to report.
 See the next section on how to customize this behavior.
-In the Go SDK `OrphanReporter` is only applicable to the key value service, other services use HTTP which is a blocking operation and cannot create orphaned requests.
+In the Go SDK `OrphanReporter` is only applicable to the key-value service, other services use HTTP which is a blocking operation and cannot create orphaned requests.
 
 The actual body of the message consists of the text `Orphaned responses observed`, followed by a compact JSON representation of the aggregated orphans.
 The following code snippet shows a prettified version of such a JSON blob:
@@ -60,7 +60,7 @@ The following code snippet shows a prettified version of such a JSON blob:
 
 Please note that we do not provide any stability guarantees on the logging output format and it might change between minor versions.
 
-JSON Output Format Descriptions
+.JSON Output Format Descriptions
 [options="header"]
 |====
 | Property       | Description

--- a/modules/howtos/pages/slow-operations-logging.adoc
+++ b/modules/howtos/pages/slow-operations-logging.adoc
@@ -1,113 +1,20 @@
 = Slow Operations Logging
 :description: Tracing information on slow operations can be found in the logs as threshold logging, orphan logging, and other span metrics.
 :page-topic-type: howto
-// :page-aliases: ROOT:
 
 [abstract]
 {description}
-Change the settings to alter how much information you collect.
+Change the settings to alter how much information you collect
 
 To improve debuggability certain metrics are automatically measured and logged.
-These include slow queries, responses taking beyond a certain threshold, and orphaned responses.
-
-
-//== Observability Metrics
-//
-//Individual request traces present a very specific (and isolated) view of the system.
-//In addition, it also makes sense to capture information that aggregates request data (i.e. requests per second),
-//but also data which is not tied to a specific request at all (i.e. resource utilization).
-//
-//The deployment situation itself is similar to the tracer: either applications already have a metrics infrastructure in place or they don’t.
-//The difference is that exposing some kind of metrics is much more common than request based tracing,
-//because most production deployments at least monitor CPU usage etc.
-//
-//Metrics fall into the following categories:
-//
-//* Request/Response Metrics (such as requests per second).
-//* SDK Metrics (such as how many open collections, various queue lengths).
-//* System Metrics (such as cpu usage, garbage collection performance).
-//
-//
-//
-//== Configuring Metrics Logging
-//
-//The information logged can be configured, although configurability does vary slightly between SDKs.
-//
-//
-//Advanced users can build their own implementations of the interface:
-//
-//[source,java]
-//----
-//interface Meter {
-//     Counter counter(String name, Map<String, String> tags)
-//     ValueRecorder valueRecorder(String name, Map<String, String> tags)
-//}
-//
-//interface Counter {
-//    void incrementBy(ulong number)
-//}
-//
-//interface ValueRecorder {
-//    void recordValue(ulong value)
-//}
-//----
-//
-// ;; The different Meter implementation names are heavily based on their _OpenTelemetry_ counterparts.
-//
-//At each emit/log interval, the AggregatingMeter outputs a JSON structure that is very similar to the `ThresholdRequestTracer` or the `OrphanResponseReporter`.
-//The default value for the `emitInterval` is 600 seconds (10 minutes).
-//
-//==== JSON Output Format & Logging
-//
-//The overall structure looks like this (here prettified for readability):
-//
-//[source,json]
-//----
-//{
-//  “meta”: {
-//	“emit_interval_s”: 600,
-//  }
-//  “<service-a>”: {
-//    “<node-a>” {
-//      “total_count”: 1234,
-//      “percentiles_us”: {
-//        “50.0”: 5,
-//        “90.0”: 10,
-//        “99.0”: 33,
-//        “99.9”: 55,
-//        “100.0”: 101,
-//      }
-//    }
-//  },
-//}
-//----
-//
-//For each service and each node, the total count and the latency percentiles are reported.
-//This will help during debugging to get a decent idea of the latency distribution across services and nodes.
-//For more sophisticated grouping and aggregations, users should use the forthcoming `OpenTelemetryMeter`, or a custom implementation.
-//
-//The `emit_interval_s` is reported in the meta section of the JSON output since to calculate the ops/s the `total_count` needs to be divided by the `emit_interval_s`.
-//Since the configuration property is not always available when debugging logs it is included to make it simple.
-
+These include slow queries, responses taking beyond a certain threshold, and orphanned responses.
 
 == Threshold Logging Reporting
 
 Threshold logging is the recording of slow operations -- useful for diagnosing when and where problems occur in a distributed environment.
 
 
-=== Configuring Threshold Logging
-
-To configure threshold logging, adjust the xref:ref:client-settings.adoc#general-options[ThresholdRequestTracer].
-For example setting the `KVThreshold` and `SampleSize` on the Threshold Logger:
-
-[source,golang,indent=0]
-----
-include::devguide:example$go/threshold-logging.go[tag=configure]
-----
-
-Note that the Threshold Logger is set as the cluster level `Tracer` implementation.
-
-==== JSON Output Format & Logging
+== Output Format
 
 You should expect to see output in JSON format in the logs for the services encountering problems:
 
@@ -125,9 +32,9 @@ You should expect to see output in JSON format in the logs for the services enco
 }
 ----
 
-The `total_count` represents the total amount of over-threshold recorded items in each interval per service. 
-The number of entries in “top_requests” is configured by the `sampleSize`. 
-The service placeholder is replaced with each service -- “kv”, “query”, etc. 
+The `total_count` represents the total amount of over-threshold recorded items in each interval per service.
+The number of entries in “top_requests” is configured by the `SampleSize`.
+The service placeholder is replaced with each service -- “kv”, “query”, etc.
 Each entry looks like this, with all fields populated:
 
 [source,json]
@@ -139,74 +46,7 @@ Each entry looks like this, with all fields populated:
   "total_dispatch_duration_us": 40,
   "last_server_duration_us": 2,
   "operation_name": "upsert",
-  "last_local_id": "66388CF5BFCF7522/18CC8791579B567C,
-  "operation_id": "0x23",
-  "last_local_socket": "10.211.55.3:52450",
-  "last_remote_socket": "10.112.180.101:11210"
-}
-----
-
-If a field is not present (because for example dispatch did not happen), it will not be included. 
-
-
-
-== Orphaned Response Reporting
-
-Orphan response reporting acts as an auxiliary tool to the tracing and metrics capabilities. 
-It does not expose an external API to the application and is very focussed on its feature set.
-
-The way it works is that every time a response is in the process of being completed, 
-when the SDK detects that the original caller is not listening anymore (likely because of a timeout), 
-it will send this “orphan” response to a reporting utility which then aggregates it and in regular intervals logs them in a specific format.
-
-When the user then sees timeouts in their logs, they can go look at the output of the orphan reporter and correlate certain properties that aid debugging in production. 
-For example, if a single node is slow but the rest of the cluster is responsive, this would be visible from orphan reporting.
-
-=== Configuring Orphan Logging
-
-The OrphanResponseReporter is very similar in principle to the ThresholdRequestTracer, 
-but instead of tracking responses which are over a specific threshold it tracks those responses which are “orphaned”. 
-
-The `ReportInterval` and `SampleSize` can be adjusted (defaults are 10s and 10 samples per service, respectively).
-
-[source,golang,indent=0]
-----
-include::devguide:example$go/orphan-logging.go[tag=configure]
-----
-
-==== JSON Output Format & Logging
-
-The overall structure looks like this (here prettified for readability):
-
-[source,json]
-----
-{
-  “<service-a>”: {
-    “total_count”: 1234,
-    “top_requests”: [{<entry>}, {<entry>},...]
-  },
-  “<service-b>”: {
-    “total_count”: 1234,
-    “top_requests”: [{<entry>}, {<entry>},...]
-  },
-}
-----
-
-The total_count represents the total amount of  recorded items in each interval per service. 
-The number of entries in “top_requests” is configured by the sampleSize. The service placeholder is replaced with each service, i.e. “kv”, “query” etc. 
-Each entry looks like this, with all fields populated:
-
-[source,json]
-----
-{
-  "total_duration_us": 1200,
-  "encode_duration_us": 100,
-  "last_dispatch_duration_us": 40,
-  "total_dispatch_duration_us": 40,
-  "last_server_duration_us": 2,
-  “timeout_ms”: 75000,
-  "operation_name": "upsert",
-  "last_local_id": "66388CF5BFCF7522/18CC8791579B567C,
+  "last_local_id": "66388CF5BFCF7522/18CC8791579B567C",
   "operation_id": "0x23",
   "last_local_socket": "10.211.55.3:52450",
   "last_remote_socket": "10.112.180.101:11210"
@@ -214,3 +54,30 @@ Each entry looks like this, with all fields populated:
 ----
 
 If a field is not present (because for example dispatch did not happen), it will not be included.
+
+
+== Configuring Threshold Logging
+
+Configuration of the `ThresholdLoggingTracer` is done on the tracer itself, at creation time.
+If no tracer is configured using `ClusterOptions.Tracer` then the default `ThresholdLoggingTracer` will be used.
+
+[source,golang,indent=0]
+----
+include::devguide:example$go/slow-operations.go[tag=config]
+----
+
+The following properties can be configured:
+
+[options="header"]
+|====
+| Property       | Default | Description
+| `Interval` | 10 seconds | The interval where found slow operations are emitted.
+| `SampleSize`   | 10 | The number of samples to store per service.
+| `KVThreshold`  | 500 milliseconds | The threshold over which the request is taken into account for the KV service.
+| `ViewsThreshold`  | 1 second | The threshold over which the request is taken into account for the views service.
+| `QueryThreshold`  | 1 second | The threshold over which the request is taken into account for the query service.
+| `SearchThreshold`  | 1 second | The threshold over which the request is taken into account for the search service.
+| `AnalyticsThreshold`  | 1 second | The threshold over which the request is taken into account for the analytics service.
+| `ManagementThreshold`  | 1 second | The threshold over which the request is taken into account for the management service.
+|====
+


### PR DESCRIPTION
The move and splitting of the file better matches Java docs
which improves UX around finding things across SDKs.