### PR TITLE
AV-35207 - Restructure Distributed ACID Transactions documentation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -14,11 +14,18 @@
 * xref:howtos:full-text-searching-with-sdk.adoc[Search]
 * xref:howtos:view-queries-with-sdk.adoc[MapReduce Views]
 
+.Transactions
+* xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[How-to Guide]
+// TODO: Add Single Query and Tracing when available in Go SDK
+//** xref:howtos:transactions-single-query.adoc[Single Query Transactions]
+//** xref:howtos:transactions-tracing.adoc[Tracing]
+* xref:concept-docs:transactions.adoc[Key Concepts]
+** xref:concept-docs:transactions-cleanup.adoc[Cleanup]
+** xref:concept-docs:transactions-error-handling.adoc[Error Handling]
 
 .Advanced Data Operations
 * xref:howtos:concurrent-async-apis.adoc[Async & Batching APIs]
 * xref:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations]
-* xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions]
 // * xref:howtos:durability.adoc[Durability]
 * xref:howtos:encrypting-using-sdk.adoc[Encrypting Your Data]
 * xref:howtos:transcoders-nonjson.adoc[Transcoders & Non-JSON]

--- a/modules/concept-docs/pages/transactions-cleanup.adoc
+++ b/modules/concept-docs/pages/transactions-cleanup.adoc
@@ -1,0 +1,79 @@
+= Cleanup
+:description: The SDK takes care of failed or lost transactions, using an asynchronous cleanup background task.
+:page-toclevels: 2
+:page-pagination: full
+
+[abstract]
+{description}
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+Transactions will try to clean up after themselves in the advent of failures. However, there are situations that inevitably created failed, or 'lost' transactions, such as an application crash.
+
+This requires an asynchronous cleanup task, described in this section.
+
+== Background Cleanup
+
+Calling `Connect` spawns a background cleanup task, whose job it is to periodically scan for expired transactions and clean them up.
+It does this by scanning a subset of the Active Transaction Record (ATR) transaction metadata documents, for each metadata collection used by any transactions.
+
+NOTE: Unless there are any metadata collections registered (either from config or by running a transaction) then the background cleanup task will do no work and so is very lightweight.
+
+The default settings are tuned to find expired transactions reasonably quickly, while creating negligible impact from the background reads required by the scanning process.
+To be exact, with default settings it will generally find expired transactions within 60 seconds, and use less than 20 reads per second.
+This is unlikely to impact performance on any cluster, but the settings may be <<tuning-cleanup,tuned>> as desired.
+
+All applications connected to the same cluster and running `Transactions` will share in the cleanup, via a low-touch communication protocol on the `_txn:client-record` metadata document that will be created in each metadata collection used during transactions.
+This document is visible and should not be modified externally as is maintained automatically.
+All ATRs on a metadata collection will be distributed between all cleanup clients, so increasing the number of applications will not increase the reads required for scanning.
+
+An application may cleanup transactions created by another application.
+
+[NOTE]
+====
+It is important to understand that if an application is not running, then cleanup is not running.
+This is particularly relevant to developers running unit tests or similar.
+
+If this is an issue, then developers may want to consider running a simple application at all times that just calls `Connect`, to guarantee that cleanup is running.
+When an application is used solely for cleanup it *must* register any collections to monitor via the `CleanupCollections` config option, otherwise the cleanup task will not do any work.
+Only the collections registered will be monitored.
+====
+
+[#tuning-cleanup]
+=== Configuring Cleanup
+
+[options="header"]
+|====
+| Setting       | Default | Description
+| `CleanupWindow` | 60 seconds | This determines how long a cleanup 'run' is; that is, how frequently this client will check its subset of ATR documents. It is perfectly valid for the application to change this setting, which is at a conservative default. Decreasing this will cause expiration transactions to be found more swiftly (generally, within this cleanup window), with the tradeoff of increasing the number of reads per second used for the scanning process.
+| `DisableLostAttemptCleanup` | false | This is the thread that takes part in the distributed cleanup process described above, that cleans up expired transactions created by any client. It is strongly recommended that it is left enabled.
+| `DisableClientAttemptCleanup` | false | This thread is for cleaning up transactions created just by this client. The client will preferentially aim to send any transactions it creates to this thread, leaving transactions for the distributed cleanup process only when it is forced to (for example, on an application crash). It is strongly recommended that it is left enabled.
+| `CleanupCollections` | `[]TransactionKeyspace{}` | This is the set of additional collections that the lost transactions cleanup task will monitor
+|====
+
+== Monitoring Cleanup
+
+To monitor cleanup, increase the verbosity on the logging.
+
+Please see the xref:howtos:collecting-information-and-logging.adoc[Go SDK logging documentation] for details.
+
+// TODO: Not sure if this applies to Go SDK...
+//=== Monitoring Cleanup
+//
+//If the application wishes to monitor cleanup it may subscribe to these events:
+//
+//[source,java]
+//----
+//include::devguide:example$go/transactionsExample.java[tag=cleanup-events,indent=0]
+//----
+//
+//`TransactionCleanupEndRunEvent` is raised whenever a current 'run' is finished, and contains statistics from the run.
+//(A run is typically around every 60 seconds, with default configuration.)
+//
+//A `TransactionCleanupAttempt` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
+//It contains whether that attempt was successful, along with any logs relevant to the attempt.
+//
+//In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttempt` event at WARN level (rather than the default DEBUG).
+//With most default configurations of the event-bus (see <<Logging>> below), this will cause that event to be logged somewhere visible to the application.
+//If there is not a good reason for the cleanup to be failed (such as a downed node that has not yet been failed-over), then the user is encouraged to report the issue.

--- a/modules/concept-docs/pages/transactions-error-handling.adoc
+++ b/modules/concept-docs/pages/transactions-error-handling.adoc
@@ -1,0 +1,34 @@
+= Error Handling
+:description:  Handling transaction errors with Couchbase.
+:page-toclevels: 2
+:page-pagination: prev
+
+[abstract]
+{description}
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error-intro]
+
+== Transaction Errors
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=configExpiration,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
+
+=== Full Error Handling Example
+
+Pulling all of the above together, this is the suggested best practice for error handling:
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=fullErrorHandling,indent=0]
+----

--- a/modules/concept-docs/pages/transactions.adoc
+++ b/modules/concept-docs/pages/transactions.adoc
@@ -1,0 +1,89 @@
+= Distributed ACID Transactions
+:description:  A high-level overview of Distributed ACID Transactions with Couchbase.
+:page-toclevels: 2
+:page-pagination: next
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+[abstract]
+{description}
+
+For a practical guide, see xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions from the Java SDK].
+
+== Overview
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=intro]
+
+== Transaction Mechanics
+
+The starting point is the `Transactions` object, which is effectively a singleton belonging to a `Cluster` object.
+Internally `Transactions` is created on `gocb.Connect(...)` and its lifetime is bound to the parent `Cluster` object.
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=init,indent=0]
+----
+
+NOTE: Multiple calls to `cluster.Transactions()` will yield the same `Transactions` object.
+This is because the `Transactions` object performs automated xref:concept-docs:transactions-cleanup.adoc[background processes] that should not be duplicated.
+
+[source,go]
+----
+include::devguide:example$/go/transactions.go[tag=create-simple,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!library-cleanup-process]
+
+=== Rollback
+
+When an error is thrown, either by the application from the {lambda}, or by the transactions logic itself (e.g. on a failed operation), then that attempt is rolled back.
+
+The application's {lambda} may or may not be retried, depending on the error that occurred.
+The general rule for retrying is whether the transaction is likely to succeed on a retry.
+For example, if this transaction is trying to write a document that is currently involved in another transaction (a write-write conflict), this will lead to a retry as that is likely a transient state.
+But if the transaction is trying to get a document that does not exist, it will not retry.
+
+If the transaction is not retried then it will return a  `{transaction-failed}` error, and its `Unwrap` function can be used for more details on the failure.
+
+The application can use this to signal why it triggered a rollback, as so:
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=rollbackCause,indent=0]
+----
+
+After a transaction is rolled back, it cannot be committed, no further operations are allowed on it, and the SDK will not try to automatically commit it at the end of the code block.
+
+== Transaction Operations
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query;!library-begin-transaction]
+
+== Concurrency with Non-Transactional Writes
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
+
+== Custom Metadata Collections
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1,indent=0]
+
+[source,go]
+----
+include::devguide:example$/go/transactions.go[tag=customMetadata,indent=0]
+----
+
+When specified:
+
+    * Any transactions created from this `Transactions` object, will create and use metadata in that collection.
+    * The asynchronous cleanup started by this `Transactions` object will be looking for expired transactions only in this collection, unless additional `CleanupCollections` are provided or a transaction explicitly overrides the metadata collection.
+
+Custom metadata collections can also be provided at the transaction level itself.
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=customMetadataTxn,indent=0]
+----
+
+This will override any metadata collection that has been provided at the `Transactions` level.
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=integrated-sdk-custom-metadata-2,indent=0]

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -1,392 +1,64 @@
 = Distributed Transactions from the Go SDK
-:description: A practical guide to using Couchbase’s distributed ACID transactions, via the Go API.
+:description: A practical guide to using Couchbase’s distributed ACID transactions, via the Go SDK.
 :navtitle: ACID Transactions
 :page-partial:
 :page-topic-type: howto
 :page-aliases: acid-transactions
 :page-toclevels: 2
+:page-pagination: next
 
 include::project-docs:partial$attributes.adoc[]
-include::partial$acid-transactions-attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
 
 [abstract]
 {description}
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=intro]
+This guide will show you examples of how to perform multi-document ACID (atomic, consistent, isolated, and durable) database transactions within your application, using the Couchbase Go SDK.
 
-== Requirements
+Refer to the xref:concept-docs:transactions.adoc[Distributed ACID Transactions] concept material for a high-level overview.
 
+== Prerequisites
+
+[{tabs}]
+====
+Couchbase Capella::
++
+--
+* Couchbase Capella account.
+* You should know how to perform xref:howtos:kv-operations.adoc[key-value] or xref:howtos:n1ql-queries-with-sdk.adoc[query] operations with the SDK.
+* Your application should have the relevant roles and permissions on the required buckets, scopes, and collections, to perform transactional operations.
+Refer to the xref:cloud:organizations:organization-projects-overview.adoc[Organizations & Access] page for more details.
+* If your application is using xref:concept-docs:xattr.adoc[extended attributes (XATTRs)], you should avoid using the XATTR field `txn` -- this is reserved for Couchbase use.
+--
+
+Couchbase Server::
++
+--
 * Couchbase Server 7.0.0 or above.
-* Couchbase Go SDK 2.4.0 or above.
+* You should know how to perform xref:howtos:kv-operations.adoc[key-value] or xref:howtos:n1ql-queries-with-sdk.adoc[query] operations with the SDK.
+* Your application should have the relevant roles and permissions on the required buckets, scopes, and collections, to perform transactional operations.
+Refer to the xref:{version-server}@server:learn:security/roles.adoc[Roles] page for more details.
+* If your application is using xref:concept-docs:xattr.adoc[extended attributes (XATTRs)], you should avoid using the XATTR field `txn` -- this is reserved for Couchbase use.
+* NTP should be configured so nodes of the Couchbase cluster are in sync with time.
+--
+====
+
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
 
-== Getting Started
-
-Couchbase transactions require no additional components or services to be configured.
-
-== Initializing Transactions
-
-The starting point is the `Transactions` object.
-The `Transactions` object is effectively a singleton belonging to a `Cluster` object, internally `Transactions` is created on `gocb.Connect(..)` and its lifetime is bound to the parent `Cluster` object.
-Multiple calls to `cluster.Transactions()` will yield the same `Transactions` object, this is because the `Transactions` object performs automated background processes that should not be duplicated.
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=init,indent=0]
-----
-
-== Configuration
-
-Transactions can optionally be globally configured at the point of creating the `Cluster` object:
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=config,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
-
+== Creating a Transaction
 
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating]
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=create,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-ctx]
-
-// Examples
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=examples-intro]
 
 [source,go]
 ----
 include::devguide:example$go/transactions.go[tag=examples,indent=0]
 ----
 
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-ctx]
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!library-cleanup-process]
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating-error]
 
-
-== Key-Value Mutations
-
-=== Replacing
-
-Replacing a document requires a `ctx.Get()` call first.
-This is necessary so that the transaction can check that the document is not involved in another transaction.
-If it is, then the SDK will handle this at the `ctx.Replace()` point.
-Generally, this involves rolling back what has been done so far, and retrying the lambda.
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=replace,indent=0]
-----
-
-=== Removing
-
-As with replaces, removing a document requires a `ctx.Get()` call first.
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=remove,indent=0]
-----
-
-=== Inserting
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=insert,indent=0]
-----
-
-== Key-Value Reads
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=get,indent=0]
-----
-
-Getting a document with Key-Value can return an `ErrDocumentNotFound` which can be ignored if you are unsure if the document exists, or it not existing does not matter:
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=getOpt,indent=0]
-----
-
-If the `ErrDocumentNotFound` is not ignored then `Get` will cause the transaction to fail with `TransactionFailedError` (after rolling back any changes, of course).
-`ErrDocumentNotFound` is one of very few errors that the SDK will allow you to ignore, the SDK internally tracks the state of the transaction and will not allow illegal operations to continue.
-
-Gets will 'read your own writes', e.g. this will succeed:
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=getReadOwnWrites,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query-intro;!library-begin-transaction]
-
-=== Using N1QL
-
-If you already use N1QL from the Go SDK, then its use in transactions is very similar.
-It returns a similar `TransactionsQueryResult`, and takes most of the same options.
-The main difference between `TransactionsQueryResult` and `QueryResult` is that `TransactionsQueryResult` does not stream results.
-This means that there are no `Err` or `Close` functions and that result sets are buffered in memory - allowing the SDK to read and handle any errors that occur on the stream before returning a result/error.
-
-You must take care to write `ctx.Query()` inside the lambda however, rather than `cluster.Query()` or `scope.Query()`.
-
-An example of selecting some rows from the `travel-sample` bucket:
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=querySelect,indent=0]
-----
-
-Rather than specifying the full "`travel-sample`.inventory.hotel" name each time, it is easier to pass a reference to the inventory `Scope`:
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=querySelectScope,indent=0]
-----
-
-An example using a `Scope` for an UPDATE operation:
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=queryUpdate,indent=0]
-----
-
-And an example combining SELECTs and UPDATEs.
-It's possible to call regular Go functions from the lambda, as shown here, permitting complex logic to be performed.
-Just remember that since the lambda may be called multiple times, so may the method.
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=queryComplex,indent=0]
-----
-
-=== Read Your Own Writes
-
-As with Key-Value operations, N1QL queries support Read Your Own Writes.
-
-This example shows inserting a document and then selecting it again.
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=queryInsert,indent=0]
-----
-
-<1> The inserted document is only staged at this point, as the transaction has not yet committed.
-Other transactions, and other non-transactional actors, will not be able to see this staged insert yet.
-<2> But the SELECT can, as we are reading a mutation staged inside the same transaction.
-
-=== Mixing Key-Value and N1QL
-
-Key-Value operations and queries can be freely intermixed, and will interact with each other as you would expect.
-
-In this example we insert a document with Key-Value, and read it with a SELECT.
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=queryRyow,indent=0]
-----
-
-<1> As with the 'Read Your Own Writes' example, here the insert is only staged, and so it is not visible to other transactions or non-transactional actors.
-<2> But the SELECT can view it, as the insert was in the same transaction.
-
-=== Query Options
-
-Query options can be provided via `TransactionQueryOptions`, which provides a subset of the options in the Go SDK's `QueryOptions`.
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=queryOptions,indent=0]
-----
-
-The supported options are:
-
-* PositionalParameters
-* NamedParameters 
-* ScanConsistency 
-* FlexIndex
-* ClientContextID
-* ScanWait
-* ScanCap
-* PipelineBatch
-* PipelineCap
-* Profile
-* Readonly
-* Raw
-
-See the xref:howtos:n1ql-queries-with-sdk.adoc#query-options[QueryOptions documentation] for details on these.
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-perf]
-
-// TODO: Add an example for these includes and then uncomment.
-//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-single]
-//
-//[source,java]
-//----
-//include::devguide:example$go/transactionsExample.java[tag=querySingle,indent=0]
-//----
-//
-//You can also run a single query transaction against a particular `Scope` (these examples will exclude the full error handling for brevity):
-//
-//[source,java]
-//----
-//include::devguide:example$go/transactionsExample.java[tag=querySingleScoped,indent=0]
-//----
-//
-//and configure it:
-//
-//[source,java]
-//----
-//include::devguide:example$go/transactionsExample.java[tag=querySingleConfigured,indent=0]
-//----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=n1ql-rbac]
-
-
-== Committing
-
-Committing is automatic: if no errors are returned, the transaction will be committed.
-
-As soon as the transaction is committed, all its changes will be atomically visible to reads from other transactions.
-The changes will also be committed (or "unstaged") so they are visible to non-transactional actors, in an eventually consistent fashion.
-
-Commit is final: after the transaction is committed, it cannot be rolled back, and no further operations are allowed on it.
-
-An asynchronous cleanup process ensures that once the transaction reaches the commit point, it will be fully committed - even if the application crashes.
-
-
-// == A Full Transaction Example
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=example]
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=full,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
-
-// concurrency
-//[source,java]
-//----
-//include::devguide:example$go/transactionsExample.java[tag=concurrency,indent=0]
-//----
-//
-//These events will be raised in the event of a non-transactional write being detected and overridden.
-//The event contains the key of the document involved, to aid the application with debugging.
-
-
-== Rollback
-
-If an exception is thrown, either by the application from the lambda, or by the transaction internally, then that attempt is rolled back.
-The transaction logic may or may not be retried, depending on the exception.
-//- see link:#error-handling[Error handling and logging].
-
-If the transaction is not retried then it will return a `TransactionFailedError` error, and its `Unwrap` function can be used for more details on the failure.
-
-The application can use this to signal why it triggered a rollback, as so:
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=rollbackCause,indent=0]
-----
-
-After a transaction is rolled back, it cannot be committed, no further operations are allowed on it.
-
-//  Error Handling
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error]
-
-There are three errors that Couchbase transactions can return to the application: `TransactionFailedError`, `TransactionExpiredError` and `TransactionCommitAmbiguousError`.
-
-
-//  txnfailed
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=configExpiration,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
-
-// TODO: Double check if this will be added in future.
-// Doesn't seem to be available for the Go SDK.
-//Similar to `TransactionResult`, `SingleQueryTransactionResult` also has an `unstagingComplete()` method.
-
-=== Full Error Handling Example
-
-Pulling all of the above together, this is the suggested best practice for error handling:
-
-[source,go]
-----
-include::devguide:example$go/transactions.go[tag=fullErrorHandling,indent=0]
-----
-
-== Asynchronous Cleanup
-
-Transactions will try to clean up after themselves in the advent of failures.
-However, there are situations that inevitably created failed, or 'lost' transactions, such as an application crash.
-
-This requires an asynchronous cleanup task, described in this section.
-
-Calling `Connect` spawns a background cleanup task, whose job it is to periodically scan for expired transactions and clean them up.
-It does this by scanning a subset of the Active Transaction Record (ATR) transaction metadata documents, for each metadata collection used by any transactions.
-As you'll recall from <<mechanics,earlier>>, an entry for each transaction attempt exists in one of these documents.
-They are removed during cleanup or at some time after successful completion.
-
-NOTE: Unless there are any metadata collections registered (either from config or by running a transaction) then the background cleanup task will do no work and so is very lightweight.
-
-The default settings are tuned to find expired transactions reasonably quickly, while creating negligible impact from the background reads required by the scanning process.
-To be exact, with default settings it will generally find expired transactions within 60 seconds, and use less than 20 reads per second.
-This is unlikely to impact performance on any cluster, but the settings may be <<tuning-cleanup,tuned>> as desired.
-
-All applications connected to the same cluster and running `Transactions` will share in the cleanup, via a low-touch communication protocol on the "_txn:client-record" metadata document that will be created in each metadata collection used during transactions.
-This document is visible and should not be modified externally as is maintained automatically.
-All ATRs on a metadata collection will be distributed between all cleanup clients, so increasing the number of applications will not increase the reads required for scanning.
-
-An application may cleanup transactions created by another application.
-
-It is important to understand that if an application is not running, then cleanup is not running.
-This is particularly relevant to developers running unit tests or similar.
-
-If this is an issue, then the deployment may want to consider running a simple application at all times that just call `Connect`, to guarantee that cleanup is running.
-When an application is used solely for cleanup it *must* register any collections to monitor via the `CleanupCollections` config option, otherwise the cleanup task will not do any work.
-Only the collections registered will be monitored.
-
-[#tuning-cleanup]
-=== Configuring Cleanup
-
-[options="header"]
-|====
-| Setting       | Default | Description
-| `CleanupWindow` | 60 seconds | This determines how long a cleanup 'run' is; that is, how frequently this client will check its subset of ATR documents. It is perfectly valid for the application to change this setting, which is at a conservative default. Decreasing this will cause expiration transactions to be found more swiftly (generally, within this cleanup window), with the tradeoff of increasing the number of reads per second used for the scanning process.
-| `DisableLostAttemptCleanup` | false | This is the thread that takes part in the distributed cleanup process described above, that cleans up expired transactions created by any client. It is strongly recommended that it is left enabled.
-| `DisableClientAttemptCleanup` | false | This thread is for cleaning up transactions created just by this client. The client will preferentially aim to send any transactions it creates to this thread, leaving transactions for the distributed cleanup process only when it is forced to (for example, on an application crash). It is strongly recommended that it is left enabled.
-| `CleanupCollections` | `[]TransactionKeyspace{}` | This is the set of additional collections that the lost transactions cleanup task will monitor
-|====
-
-
-//=== Monitoring Cleanup
-//
-//If the application wishes to monitor cleanup it may subscribe to these events:
-//
-//[source,java]
-//----
-//include::devguide:example$go/transactionsExample.java[tag=cleanup-events,indent=0]
-//----
-//
-//`TransactionCleanupEndRunEvent` is raised whenever a current 'run' is finished, and contains statistics from the run.
-//(A run is typically around every 60 seconds, with default configuration.)
-//
-//A `TransactionCleanupAttempt` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
-//It contains whether that attempt was successful, along with any logs relevant to the attempt.
-//
-//In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttempt` event at WARN level (rather than the default DEBUG).
-//With most default configurations of the event-bus (see <<Logging>> below), this will cause that event to be logged somewhere visible to the application.
-//If there is not a good reason for the cleanup to be failed (such as a downed node that has not yet been failed-over), then the user is encouraged to report the issue.
-
-== Logging
+=== Logging
 
 To aid troubleshooting, raise the log level on the SDK.
 // TODO: need to add logging details
@@ -408,102 +80,213 @@ To aid troubleshooting, raise the log level on the SDK.
 
 Please see the xref:howtos:collecting-information-and-logging.adoc[Go SDK logging documentation] for details.
 
-// TODO: re-add this once tracing becomes available
-//== Tracing
-//
-//This telemetry is particularly useful for monitoring performance.
-//
-//If the underlying Couchbase Java SDK is configured for tracing, then no further work is required: transaction spans will be output automatically.
-//See the xref:howtos:observability-tracing.adoc[Couchbase Java SDK Request Tracing documentation] for how to configure this.
-//
-//=== Parent Spans
-//
-//While the above is sufficient to use and output transaction spans, the application may wish to indicate that the transaction is part of a larger span -- for instance, a user request.
-//It can do this by passing that as a parent span.
-//
-//If you have an existing OpenTelemetry span you can easily convert it to a Couchbase `RequestSpan` and pass it to the transactions library:
-//
-//[source,java]
-//----
-//include::devguide:example$go/transactionsExample.java[tag=tracing-wrapped,indent=0]
-//----
-//
-//== Concurrent Operations with the Async API
-//
-//The async API allows operations to be performed concurrently inside a transaction, which can assist performance.
-//There are two rules the application needs to follow:
-//
-//* The first mutation must be performed alone, in serial.
-//This is because the first mutation also triggers the creation of metadata for the transaction.
-//* All concurrent operations must be allowed to complete fully, so the transaction library can track which operations need to be rolled back in the event of failure.
-//This means the application must 'swallow' the error, but record that an error occurred, and then at the end of the concurrent operations, if an error occurred, throw an error to cause the transaction to retry.
-//
-//These rules are demonstrated here:
-//
-//[source,java]
-//----
-//include::devguide:example$go/transactionsExample.java[tag=concurrentOps,indent=0]
-//----
-//
-//
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1]
+== Key-Value Operations
+
+You can perform transactional database operations using familiar key-value CRUD methods:
+
+* **C**reate - `Insert()`
+
+* **R**ead - `Get()`
+
+* **U**pdate - `Replace()`
+
+* **D**elete - `Remove()`
+
+[IMPORTANT]
+====
+As mentioned <<lambda-ops,previously>>, make sure your application uses the transactional key-value operations inside the {lambda} -- such as `ctx.Insert()`, rather than `collection.Insert()`.
+====
+
+=== Insert
+
+To insert a document within a transaction {lambda}, simply call `ctx.Insert()`.
 
 [source,go]
 ----
-include::devguide:example$go/transactions.go[tag=customMetadata,indent=0]
+include::devguide:example$go/transactions.go[tag=insert,indent=0]
 ----
 
-When specified:
+=== Get
 
-    * Any transactions created from this `Transactions` object, will create and use metadata in that collection.
-    * The asynchronous cleanup started by this `Transactions` object will be looking for expired transactions only in this collection, unless additional `CleanupCollections` are provided or a transaction explicitly overrides the metadata collection.
-
-You need to ensure that this application has RBAC data read and write privileges to it, and should not delete the collection subsequently as it can interfere with existing transactions. 
-You can use an existing collection or create a new one.
-
-Custom metadata collections can also be provided at the transaction level itself:
+To retrieve a document from the database you can call `ctx.Get()`.
 
 [source,go]
 ----
-include::devguide:example$go/transactions.go[tag=customMetadataTxn,indent=0]
+include::devguide:example$go/transactions.go[tag=get,indent=0]
 ----
 
-This will override any metadata collection that has been provided at the `Transactions` level.
+`ctx.Get()` will return a `TransactionGetResult` object, which is very similar to the `GetResult` you are used to.
 
-//
-//== Deferred Commits
-//
-//NOTE: The deferred commit feature is currently in alpha, and the API may change.
-//
-//Deferred commits allow a transaction to be paused just before the commit point.
-//Optionally, everything required to finish the transaction can then be bundled up into a context that may be serialized into a String or byte array, and deserialized elsewhere (for example, in another process).
-//The transaction can then be committed, or rolled back.
-//
-//The intention behind this feature is to allow multiple transactions, potentially spanning multiple databases, to be brought to just before the commit point, and then all committed together.
-//
-//Here's an example of deferring the initial commit and serializing the transaction:
-//
+Getting a document could potentially return an `ErrDocumentNotFound` which can be ignored, if you are unsure whether the document exists or not, or if it not existing does not matter:
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=getOpt,indent=0]
+----
+
+If the `ErrDocumentNotFound` is not ignored then `Get` will cause the transaction to fail with `TransactionFailedError` (after rolling back any changes, of course).
+`ErrDocumentNotFound` is one of very few errors that the SDK will allow you to ignore, as the SDK internally tracks the state of the transaction and will not allow illegal operations to continue.
+
+Gets will "Read Your Own Writes", e.g. this will succeed:
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=getReadOwnWrites,indent=0]
+----
+
+=== Replace
+
+Replacing a document requires a `ctx.Get()` call first.
+This is necessary so the SDK can check that the document is not involved in another transaction, and take appropriate action if so.
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=replace,indent=0]
+----
+
+=== Remove
+
+As with replaces, removing a document requires a `ctx.Get()` call first.
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=remove,indent=0]
+----
+
+== {sqlpp} Queries
+
+If you already use https://www.couchbase.com/products/n1ql[{sqlpp} (formerly N1QL)], then its use in transactions is very similar.
+A query returns a `TransactionQueryResult` that is very similar to the `QueryResult` you are used to, and takes most of the same options.
+
+The main difference between `TransactionsQueryResult` and `QueryResult` is that `TransactionsQueryResult` does not stream results.
+This means that there are no `Err` or `Close` functions and that result sets are buffered in memory - allowing the SDK to read and handle any errors that occur on the stream before returning a result/error.
+
+[IMPORTANT]
+====
+As mentioned <<lambda-ops,previously>>, make sure your application uses the transactional query operations inside the {lambda} -- such as `ctx.Query()`, rather than `cluster.Query()` or `scope.Query()`.
+====
+
+Here is an example of selecting some rows from the `travel-sample` bucket:
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=querySelectScope,indent=0]
+----
+
+An example using a `Scope` for an UPDATE operation:
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=queryUpdate,indent=0]
+----
+
+And an example combining `SELECT` and `UPDATE`.
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=queryComplex,indent=0]
+----
+
+As you can see from the snippet above, it is possible to call regular Go methods from the {lambda}, permitting complex logic to be performed.
+Just remember that since the {lambda} may be called multiple times, so may the method.
+
+Like key-value operations, queries support "Read Your Own Writes".
+This example shows inserting a document and then selecting it again:
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=queryInsert,indent=0]
+----
+
+<1> The inserted document is only staged at this point, as the transaction has not yet committed. +
+Other transactions, and other non-transactional actors, will not be able to see this staged insert yet.
+<2> But the `SELECT` can, as we are reading a mutation staged inside the same transaction.
+
+=== Query Options
+
+Query options can be provided via `TransactionQueryOptions`, which provides a subset of the options in the Go SDK's `QueryOptions`.
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=queryOptions,indent=0]
+----
+
+.Supported Transaction Query Options
+|===
+| Name | Description
+
+| `PositionalParameters([]interface{})` | Allows to set positional arguments for a parameterized query.
+| `NamedParameters(map[string]interface{})` | Allows you to set named arguments for a parameterized query.
+| `ScanConsistency(QueryScanConsistency)` | Sets a different scan consistency for this query.
+| `FlexIndex(bool)` | Tells the query engine to use a flex index (utilizing the search service).
+| `ClientContextID(string)` | Sets a context ID returned by the service for debugging purposes.
+| `ScanWait(time.Duration)` | Allows to specify a maximum scan wait time.
+| `ScanCap(uint32)` | Specifies a maximum cap on the query scan size.
+| `PipelineBatch(uint32)` | Sets the batch size for the query pipeline.
+| `PipelineCap(uint32)` | Sets the cap for the query pipeline.
+| `Profile(QueryProfileMode)` | Allows you to enable additional query profiling as part of the response.
+| `Readonly(bool)` | Tells the client and server that this query is readonly.
+| `Prepared(bool)` | If set to false will prepare the query and later execute the prepared statement.
+| `Raw(map[str]interface{})` | Escape hatch to add arguments that are not covered by these options.
+|===
+
+== Mixing Key-Value and {sqlpp}
+
+Key-Value operations and queries can be freely intermixed, and will interact with each other as you would expect.
+In this example we insert a document with a key-value operation, and read it with a `SELECT` query.
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=queryRyow,indent=0]
+----
+
+<1> The key-value insert operation is only staged, and so it is not visible to other transactions or non-transactional actors.
+<2> But the `SELECT` can view it, as the insert was in the same transaction.
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=rbac]
+
+== Concurrent Operations
+
+The API allows operations to be performed concurrently inside a transaction, which can assist performance.
+There are two rules the application needs to follow:
+
+* The first mutation must be performed alone, in serial.
+This is because the first mutation also triggers the creation of metadata for the transaction.
+* All concurrent operations must be allowed to complete fully, so the transaction can track which operations need to be rolled back in the event of failure.
+This means the application must 'swallow' the error, but record that an error occurred, and then at the end of the concurrent operations, if an error occurred, throw an error to cause the transaction to retry.
+
+=== Non-Transactional Writes
+
+To ensure key-value performance is not compromised, and to avoid conflicting writes, applications should *never* perform non-transactional _writes_ concurrently with transactional ones, on the same document.
+
+// TODO: update this for Go, if available
+//You can verify this when debugging your application by subscribing to the client's event logger and checking for any `IllegalDocumentStateEvent` events.
+//These events are raised when a non-transactional write has been detected and overridden.
+
 //[source,java]
 //----
-//include::devguide:example$go/transactionsExample.java[tag=defer1,indent=0]
+//include::howtos:example$TransactionsExample.java[tag=concurrency,indent=0]
 //----
-//
-//And then committing the transaction later:
-//
-//[source,java]
-//----
-//include::devguide:example$go/transactionsExample.java[tag=defer2,indent=0]
-//----
-//
-//Alternatively the transaction can be rolled back:
-//
-//[source,java]
-//----
-//include::devguide:example$go/transactionsExample.java[tag=defer3,indent=0]
-//----
-//
-//The transaction expiry timer (which is configurable) will begin ticking once the transaction starts, and is not paused while the transaction is in a deferred state.
-//
-//
-//
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=further]
+
+//The event contains the key of the document involved, to aid the application with debugging.
+
+See xref:concept-docs:transactions.adoc#concurrency-with-non-transactional-writes[Concurrency with Non-Transactional Writes] to learn more.
+
+== Configuration
+
+The default configuration should be appropriate for most use-cases.
+Transactions can optionally be globally configured at the point of creating the `Cluster` object.
+For example, if you want to change the level of durability which must be attained, this can be configured as part of the connect options:
+
+[source,go]
+----
+include::devguide:example$go/transactions.go[tag=config,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
+
+== Additional Resources
+
+* Learn more about xref:concept-docs:transactions.adoc[Distributed ACID Transactions].
+
+* Check out the SDK https://pkg.go.dev/github.com/couchbase/gocb/v2[API Reference].

--- a/modules/howtos/pages/transactions-single-query.adoc
+++ b/modules/howtos/pages/transactions-single-query.adoc
@@ -1,0 +1,33 @@
+// TODO: Add when available for Go SDK (Currently this is "Uncommitted")
+// See "AsTransaction" for reference - https://pkg.go.dev/github.com/couchbase/gocb/v2#QueryOptions
+//= Single Query Transactions
+//:description: Learn how to perform bulk-loading transactions with the Python SDKd.
+//:page-partial:
+//:page-topic-type: howto
+//:page-pagination: full
+//
+//include::project-docs:partial$attributes.adoc[]
+//
+//[abstract]
+//{description}
+//
+//include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=single-query-transactions-intro]
+//
+//[source,java]
+//----
+//include::devguide:example$go/transactionsExample.java[tag=querySingle,indent=0]
+//----
+//
+//You can also run a single query transaction against a particular `Scope` (these examples will exclude the full error handling for brevity):
+//
+//[source,java]
+//----
+//include::devguide:example$go/transactionsExample.java[tag=querySingleScoped,indent=0]
+//----
+//
+//and configure it:
+//
+//[source,java]
+//----
+//include::devguide:example$go/transactionsExample.java[tag=querySingleConfigured,indent=0]
+//----

--- a/modules/howtos/pages/transactions-tracing.adoc
+++ b/modules/howtos/pages/transactions-tracing.adoc
@@ -1,0 +1,35 @@
+// TODO: Add when available for Go SDK
+//= Tracing
+//:description: Tracing Couchbase Distributed ACID transactions.
+//:page-partial:
+//:page-topic-type: howto
+//:page-pagination: full
+//
+//[abstract]
+//{description}
+//
+//If configured, detailed telemetry on each transaction can be output that is compatible with various external systems including OpenTelemetry and its predecessor OpenTracing.
+//This telemetry is particularly useful for monitoring performance.
+//
+//See the xref:howtos:observability-tracing.adoc[SDK Request Tracing documentation] for how to configure this.
+//
+//// TODO: Check if this is still the case?
+//Tracing should currently be regarded as 'developer preview' functionality, as the spans and attributes output may change over time.
+//
+//== Parent Spans
+//
+//The application may wish to indicate that the transaction is part of a larger span -- for instance, a user request.
+//It can do this by passing that as a parent span.
+//
+//This can be done using the SDK's `RequestTracer` abstraction as so:
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=tracing,indent=0]
+//----
+//
+//Or if you have an existing OpenTelemetry span you can easily convert it to a Couchbase `RequestSpan` and pass it to the SDK:
+//
+//[source,java]
+//----
+//include::example$TransactionsExample.java[tag=tracing-wrapped,indent=0]
+//----

--- a/modules/howtos/partials/acid-transactions-attributes.adoc
+++ b/modules/howtos/partials/acid-transactions-attributes.adoc
@@ -21,3 +21,7 @@
 :transaction-config: TransactionsConfig
 :transaction-commit-ambiguous: TransactionCommitAmbiguousError
 :txnfailed-unstaging-complete: TransactionResult.UnstagingComplete
+
+// lambda
+:lambda: function literal
+:intro-lambda: pass:q[a `function literal`]


### PR DESCRIPTION
Page previews (including sdk-common changes, so it's easier to see it all together):

[Transactions howto guide](https://maria-robobug.github.io/transactions-reorg/go-sdk/2.5/howtos/distributed-acid-transactions-from-the-sdk.html)

[Transactions concept guide](https://maria-robobug.github.io/transactions-reorg/go-sdk/2.5/concept-docs/transactions.html)

NUX improvements:

* Splits howto and concept content as well as removing repetitive sections.

* Adds Capella in Prerequisites.

* Removes repetitive examples from asciidoc where possible.

* Moves Transactions to top level nav, include concept and howto in same section.