### PR TITLE
Add release notes for v2.7.0

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 
-GO_VERSION ?="1.13"
+GO_VERSION ?="1.19"
 GOCB_VERSION ?="v2.2.1"
 
 CB_EDITION ?=couchbase/server:enterprise

--- a/modules/concept-docs/examples/go.mod
+++ b/modules/concept-docs/examples/go.mod
@@ -1,5 +1,5 @@
 module examples
 
-go 1.13
+go 1.19
 
-require github.com/couchbase/gocb/v2 v2.6.4
+require github.com/couchbase/gocb/v2 v2.7.0

--- a/modules/devguide/examples/go/go.mod
+++ b/modules/devguide/examples/go/go.mod
@@ -1,9 +1,9 @@
 module examples
 
-go 1.13
+go 1.19
 
 require (
-	github.com/couchbase/gocb/v2 v2.6.4
+	github.com/couchbase/gocb/v2 v2.7.0
 	github.com/couchbase/gocbencryption/v2 v2.0.0
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7

--- a/modules/hello-world/examples/go.mod
+++ b/modules/hello-world/examples/go.mod
@@ -1,5 +1,5 @@
 module examples
 
-go 1.13
+go 1.19
 
-require github.com/couchbase/gocb/v2 v2.6.4
+require github.com/couchbase/gocb/v2 v2.7.0

--- a/modules/howtos/examples/go.mod
+++ b/modules/howtos/examples/go.mod
@@ -1,5 +1,5 @@
 module examples
 
-go 1.13
+go 1.19
 
-require github.com/couchbase/gocb/v2 v2.6.4
+require github.com/couchbase/gocb/v2 v2.7.0

--- a/modules/project-docs/examples/go.mod
+++ b/modules/project-docs/examples/go.mod
@@ -1,5 +1,5 @@
 module examples
 
-go 1.13
+go 1.19
 
-require github.com/couchbase/gocb/v2 v2.6.4
+require github.com/couchbase/gocb/v2 v2.7.0

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -46,7 +46,7 @@ include::{version-common}@sdk:shared:partial$migration.adoc[tag=lang]
 The Go SDK 2.x is available for download using the go modules system.  All releases are posted to the couchbase/gocb
 GitHub repository and can be used by simply importing `github.com/couchbase/gocb/v2` and invoking `go get`.
 
-IMPORTANT: Go SDK 2.x has a minimum required Go version of 1.13, although we recommend running the latest LTS version with the highest patch version available.
+IMPORTANT: Go SDK 2.x has a minimum required Go version of 1.19, although we recommend running the latest LTS version with the highest patch version available.
 
 Almost all configuration for the SDK can be specified through the ConnectOptions which are passed to the
 `gocb.Connect` call in the SDK.  In addition to this, as with SDK 2.0, the majority of these options can

--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -25,7 +25,7 @@ IMPORTANT: `go get` only works if you have initialised a https://go.dev/blog/usi
 
 [source,console]
 ----
-$ go get github.com/couchbase/gocb/v2@v2.6.4
+$ go get github.com/couchbase/gocb/v2@v2.7.0
 ----
 
 NOTE: In line with the https://golang.org/doc/devel/release.html#policy[Golang project], Couchbase supports both the current, and the previous, versions of Go.

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -44,29 +44,29 @@ https://pkg.go.dev/github.com/couchbase/gocb/v2@v2.7.0?tab=doc[API Documentation
 
 ==== New Features and Behavioral Changes
 
-* https://issues.couchbase.com/browse/GOCBC-1322][GOCBC-1322]:
+* https://issues.couchbase.com/browse/GOCBC-1322[GOCBC-1322]:
 Added RangeScan support as API stability volatile.
-* https://issues.couchbase.com/browse/GOCBC-1391][GOCBC-1391]:
+* https://issues.couchbase.com/browse/GOCBC-1391[GOCBC-1391]:
 Deprecated the use of `CollectionName` and `ScopeName` for query index options blocks, use `collection.QueryIndexes()` instead.
-* https://issues.couchbase.com/browse/GOCBC-1394][GOCBC-1394]:
+* https://issues.couchbase.com/browse/GOCBC-1394[GOCBC-1394]:
 Updated requests against HTTP APIs to always encode URIs.
-* https://issues.couchbase.com/browse/GOCBC-1397][GOCBC-1397]:
+* https://issues.couchbase.com/browse/GOCBC-1397[GOCBC-1397]:
 Added support for the `couchbase2://` protocol.
-* https://issues.couchbase.com/browse/GOCBC-1414][GOCBC-1414]:
+* https://issues.couchbase.com/browse/GOCBC-1414[GOCBC-1414]:
 The SDK no longer supports Go versions below 1.19, due to versions enforced by dependencies.
-* https://issues.couchbase.com/browse/GOCBC-1434][GOCBC-1434]:
+* https://issues.couchbase.com/browse/GOCBC-1434[GOCBC-1434]:
 Added `LookupInAnyReplica` and `LookupInAllReplicas` support as API stability volatile.
-* https://issues.couchbase.com/browse/GOCBC-1436][GOCBC-1436]:
+* https://issues.couchbase.com/browse/GOCBC-1436[GOCBC-1436]:
 Added `UseReplica` to `QueryOptions` as API stability uncommitted.
-* https://issues.couchbase.com/browse/GOCBC-1439][GOCBC-1439]:
+* https://issues.couchbase.com/browse/GOCBC-1439[GOCBC-1439]:
 Added support for Config Push Negotiation and faster failover.
-* https://issues.couchbase.com/browse/GOCBC-1454][GOCBC-1454]:
+* https://issues.couchbase.com/browse/GOCBC-1454[GOCBC-1454]:
 Added support for JSON marshalling/unmarshalling of search indexes.
-* https://issues.couchbase.com/browse/GOCBC-1457][GOCBC-1457]:
+* https://issues.couchbase.com/browse/GOCBC-1457[GOCBC-1457]:
 Reduced the default http idle timeout to 1s.
-* https://issues.couchbase.com/browse/GOCBC-1459][GOCBC-1459]:
+* https://issues.couchbase.com/browse/GOCBC-1459[GOCBC-1459]:
 Added support for history retention settings to bucket and collections managers, at API stability uncommitted.
-* https://issues.couchbase.com/browse/GOCBC-1461][GOCBC-1461]:
+* https://issues.couchbase.com/browse/GOCBC-1461[GOCBC-1461]:
 Updated `ExistsSpec` response to handle `ContentAt` better:
     ** Assign true if the path does exists
     ** Assign false if the path does not exist
@@ -74,12 +74,13 @@ Updated `ExistsSpec` response to handle `ContentAt` better:
 
 ==== Fixed Issues
 
-* https://issues.couchbase.com/browse/GOCBC-1471][GOCBC-1471]:
+* https://issues.couchbase.com/browse/GOCBC-1471[GOCBC-1471]:
 Fixed issue where calling `.Bucket` immediately after `.Connect` could lead to the config poller failing to stop.
-* https://issues.couchbase.com/browse/GOCBC-1479][GOCBC-1479]:
+* https://issues.couchbase.com/browse/GOCBC-1479[GOCBC-1479]:
 Fixed issue where a cluster config fetched as a part of bootstrap would be applied even if select bucket failed.
-* https://issues.couchbase.com/browse/GOCBC-1460][GOCBC-1460]:
+* https://issues.couchbase.com/browse/GOCBC-1460[GOCBC-1460]:
 Fixed issue where a path mismatch status code was not converted to `ErrPathMismatch`.
+
 
 == Go SDK 2.6 Releases
 

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -16,7 +16,7 @@ For release notes, download links, and installation methods for 1.6 and earlier 
 
 [source,console]
 ----
-$ go get github.com/couchbase/gocb/v2@v2.6.4
+$ go get github.com/couchbase/gocb/v2@v2.7.0
 ----
 
 NOTE: In line with the https://golang.org/doc/devel/release.html#policy[Golang project], we support both the current, and the previous, versions of Go.
@@ -36,9 +36,50 @@ We always recommend using the latest version of the SDK -- it contains all of th
 All patch releases for each dot minor release should be API compatible, and safe to upgrade;
 any changes to expected behavior are noted in the release notes that follow.
 
+=== Version 2.7.0 (1 November 2023)
 
+Version 2.7.0 is the first release in the Go SDK 2.7 series.
 
+https://pkg.go.dev/github.com/couchbase/gocb/v2@v2.7.0?tab=doc[API Documentation]
 
+==== New Features and Behavioral Changes
+
+* https://issues.couchbase.com/browse/GOCBC-1322][GOCBC-1322]:
+Added RangeScan support as API stability volatile.
+* https://issues.couchbase.com/browse/GOCBC-1391][GOCBC-1391]:
+Deprecated the use of `CollectionName` and `ScopeName` for query index options blocks, use `collection.QueryIndexes()` instead.
+* https://issues.couchbase.com/browse/GOCBC-1394][GOCBC-1394]:
+Updated requests against HTTP APIs to always encode URIs.
+* https://issues.couchbase.com/browse/GOCBC-1397][GOCBC-1397]:
+Added support for the `couchbase2://` protocol.
+* https://issues.couchbase.com/browse/GOCBC-1414][GOCBC-1414]:
+The SDK no longer supports Go versions below 1.19, due to versions enforced by dependencies.
+* https://issues.couchbase.com/browse/GOCBC-1434][GOCBC-1434]:
+Added `LookupInAnyReplica` and `LookupInAllReplicas` support as API stability volatile.
+* https://issues.couchbase.com/browse/GOCBC-1436][GOCBC-1436]:
+Added `UseReplica` to `QueryOptions` as API stability uncommitted.
+* https://issues.couchbase.com/browse/GOCBC-1439][GOCBC-1439]:
+Added support for Config Push Negotiation and faster failover.
+* https://issues.couchbase.com/browse/GOCBC-1454][GOCBC-1454]:
+Added support for JSON marshalling/unmarshalling of search indexes.
+* https://issues.couchbase.com/browse/GOCBC-1457][GOCBC-1457]:
+Reduced the default http idle timeout to 1s.
+* https://issues.couchbase.com/browse/GOCBC-1459][GOCBC-1459]:
+Added support for history retention settings to bucket and collections managers, at API stability uncommitted.
+* https://issues.couchbase.com/browse/GOCBC-1461][GOCBC-1461]:
+Updated `ExistsSpec` response to handle `ContentAt` better:
+    ** Assign true if the path does exists
+    ** Assign false if the path does not exist
+    ** Return an error for all other statuses
+
+==== Fixed Issues
+
+* https://issues.couchbase.com/browse/GOCBC-1471][GOCBC-1471]:
+Fixed issue where calling `.Bucket` immediately after `.Connect` could lead to the config poller failing to stop.
+* https://issues.couchbase.com/browse/GOCBC-1479][GOCBC-1479]:
+Fixed issue where a cluster config fetched as a part of bootstrap would be applied even if select bucket failed.
+* https://issues.couchbase.com/browse/GOCBC-1460][GOCBC-1460]:
+Fixed issue where a path mismatch status code was not converted to `ErrPathMismatch`.
 
 == Go SDK 2.6 Releases
 
@@ -46,7 +87,7 @@ any changes to expected behavior are noted in the release notes that follow.
 
 Version 2.6.5 is a maintenance release for the Go SDK 2.6.
 
-https://pkg.go.dev/github.com/couchbase/gocb/v2@v2.6.4?tab=doc[API Documentation]
+https://pkg.go.dev/github.com/couchbase/gocb/v2@v2.6.5?tab=doc[API Documentation]
 
 ==== New Features and Behavioral Changes
 

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -36,7 +36,7 @@ We always recommend using the latest version of the SDK -- it contains all of th
 All patch releases for each dot minor release should be API compatible, and safe to upgrade;
 any changes to expected behavior are noted in the release notes that follow.
 
-=== Version 2.7.0 (1 November 2023)
+=== Version 2.7.0 (21 November 2023)
 
 Version 2.7.0 is the first release in the Go SDK 2.7 series.
 


### PR DESCRIPTION
Adding this ahead of release. This will not yet build as 2.7.0 is not released.