### PR TITLE
[AV-82442] Update Go release 2.5 docs for Free Tier

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -40,7 +40,7 @@ or the xref:7.1@server:manage:manage-settings/install-sample-buckets.adoc#instal
 --
 ====
 
-The Couchbase Capella free trial version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
+The Couchbase Capella free tier version comes with the Travel Sample Bucket, and its Query indexes, loaded and ready.
 
 
 == Quick Installation


### PR DESCRIPTION
Removed mentions of trial in the Go SDK docs. Only locations found were the start-using-sdk.adoc page. 