### PR TITLE
Adding the preview/HEAD.yml file and the Tip about FTS Limits Cap

### DIFF
--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -56,6 +56,18 @@ A conjunction query contains multiple child queries; its result documents must s
 include::devguide:example$go/search.go[tag=conjunctionquery]
 ----
 
+[TIP]
+.Search Results Limit
+====
+By default, the Search Service returns only the first 10 matches (`size: 10`, `from: 0`).
+To retrieve more results, you must explicitly define pagination settings such as `size` or `from` in your query.
+
+For information about formatting your Search query and specifying limits, see xref:server:search:search-request-params.adoc[].
+
+For information about pagination in Search responses, see xref:server:fts:fts-search-response.adoc#pagination[Pagination].
+====
+
+
 == Working with Results
 
 The result of a search query has three components: rows, facets, and metdata. 

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-server:
+    branches: release/8.0
+  docs-devex:
+    branches: release/8.0


### PR DESCRIPTION
[DOC-14069](https://jira.issues.couchbase.com/browse/DOC-14069)

Added a TIP about the FTS search results limit. Added a couple of hyperlinks pointing to docs that reside in the docs-server and docs-devex repos. Also added the preview directory and HEAD.yml file as the docs-sdk-go repo did not have them.

[Doc Preview](https://preview.docs-test.couchbase.com/docs-sdk-go-DOC-14069_GO_FTS_Limits_Cap/go-sdk/current/howtos/full-text-searching-with-sdk.html)

[DOC-14069]: https://couchbasecloud.atlassian.net/browse/DOC-14069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ