### PR TITLE
GOCBC-1830: Update student record example project structure

### DIFF
--- a/modules/devguide/examples/go/student-record/add_enrollments/main.go
+++ b/modules/devguide/examples/go/student-record/add_enrollments/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
 	"log"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
+	"github.com/sirupsen/logrus"
+
+	"student-record/internal"
 )
 
 func main() {
@@ -14,7 +16,7 @@ func main() {
 	password := "<<password>>"                  // Replace this with password from cluster access credentials
 
 	// Setup info level logging.
-	gocb.SetLogger(NewLogger(logrus.InfoLevel))
+	gocb.SetLogger(internal.NewLogger(logrus.InfoLevel))
 
 	options := gocb.ClusterOptions{
 		Authenticator: gocb.PasswordAuthenticator{

--- a/modules/devguide/examples/go/student-record/art_school_retriever/main.go
+++ b/modules/devguide/examples/go/student-record/art_school_retriever/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"log"
 
 	"github.com/couchbase/gocb/v2"
+	"github.com/sirupsen/logrus"
+
+	"student-record/internal"
 )
 
 func main() {
@@ -14,7 +16,7 @@ func main() {
 	password := "<<password>>"                  // Replace this with password from cluster access credentials
 
 	// Setup info level logging.
-	gocb.SetLogger(NewLogger(logrus.InfoLevel))
+	gocb.SetLogger(internal.NewLogger(logrus.InfoLevel))
 
 	options := gocb.ClusterOptions{
 		Authenticator: gocb.PasswordAuthenticator{
@@ -32,7 +34,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	retrieveCourses(cluster)
+	retrieveCoursesWithParameters(cluster)
 
 	err = cluster.Close(nil)
 	if err != nil {
@@ -40,10 +42,14 @@ func main() {
 	}
 }
 
-func retrieveCourses(cluster *gocb.Cluster) {
+func retrieveCoursesWithParameters(cluster *gocb.Cluster) {
 	queryResult, err := cluster.Query(
-		"SELECT crc.* FROM `student-bucket`.`art-school-scope`.`course-record-collection` crc",
-		&gocb.QueryOptions{},
+		"SELECT crc.* FROM `student-bucket`.`art-school-scope`.`course-record-collection` crc WHERE crc.`credit-points` < $credits",
+		&gocb.QueryOptions{
+			NamedParameters: map[string]interface{}{
+				"credits": 200,
+			},
+		},
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/modules/devguide/examples/go/student-record/art_school_retriever_all/main.go
+++ b/modules/devguide/examples/go/student-record/art_school_retriever_all/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"log"
 
 	"github.com/couchbase/gocb/v2"
+	"github.com/sirupsen/logrus"
+
+	"student-record/internal"
 )
 
 func main() {
@@ -14,7 +16,7 @@ func main() {
 	password := "<<password>>"                  // Replace this with password from cluster access credentials
 
 	// Setup info level logging.
-	gocb.SetLogger(NewLogger(logrus.InfoLevel))
+	gocb.SetLogger(internal.NewLogger(logrus.InfoLevel))
 
 	options := gocb.ClusterOptions{
 		Authenticator: gocb.PasswordAuthenticator{
@@ -32,7 +34,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	retrieveCoursesWithParameters(cluster)
+	retrieveCourses(cluster)
 
 	err = cluster.Close(nil)
 	if err != nil {
@@ -40,14 +42,10 @@ func main() {
 	}
 }
 
-func retrieveCoursesWithParameters(cluster *gocb.Cluster) {
+func retrieveCourses(cluster *gocb.Cluster) {
 	queryResult, err := cluster.Query(
-		"SELECT crc.* FROM `student-bucket`.`art-school-scope`.`course-record-collection` crc WHERE crc.`credit-points` < $credits",
-		&gocb.QueryOptions{
-			NamedParameters: map[string]interface{}{
-				"credits": 200,
-			},
-		},
+		"SELECT crc.* FROM `student-bucket`.`art-school-scope`.`course-record-collection` crc",
+		&gocb.QueryOptions{},
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/modules/devguide/examples/go/student-record/connect_student/main.go
+++ b/modules/devguide/examples/go/student-record/connect_student/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
+	"fmt"
 	"log"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
+	"github.com/sirupsen/logrus"
+
+	"student-record/internal"
 )
 
 func main() {
@@ -14,8 +17,9 @@ func main() {
 	password := "<<password>>"                  // Replace this with password from cluster access credentials
 
 	// Setup info level logging.
-	gocb.SetLogger(NewLogger(logrus.InfoLevel))
+	gocb.SetLogger(internal.NewLogger(logrus.InfoLevel))
 
+	// Connecting to the cluster
 	options := gocb.ClusterOptions{
 		Authenticator: gocb.PasswordAuthenticator{
 			Username: username,
@@ -23,6 +27,7 @@ func main() {
 		},
 	}
 
+	// Use the pre-configured profile below to avoid latency issues with your connection.
 	if err := options.ApplyProfile(gocb.ClusterConfigProfileWanDevelopment); err != nil {
 		log.Fatal(err)
 	}
@@ -32,30 +37,25 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// The `cluster.Bucket` retrieves the bucket you set up for the student cluster.
 	bucket := cluster.Bucket("student-bucket")
+
+	// Forces the application to wait until the bucket is ready.
 	err = bucket.WaitUntilReady(10*time.Second, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	// The `bucket.Scope` retrieves the `art-school-scope` from the bucket.
 	scope := bucket.Scope("art-school-scope")
+
+	// The `scope.Collection` retrieves the student collection from the scope.
 	studentRecords := scope.Collection("student-record-collection")
 
-	// Create and populate the student record.
-	hilary := map[string]interface{}{
-		"name":          "Hilary Smith",
-		"date-of-birth": "1980-12-21",
-	}
+	// A check to make sure the collection is connected and retrieved when you run the application.
+	fmt.Println("The name of this collection is", studentRecords.Name())
 
-	// The `Upsert` function inserts or updates documents in a collection.
-	// The first parameter is a unique ID for the document, similar to a primary key used in a relational database system.
-	// If the `Upsert` call finds a document with a matching ID in the collection, it updates the document.
-	// If there is no matching ID, it creates a new document.
-	_, err = studentRecords.Upsert("000001", hilary, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	// Like with all database systems, it's good practice to disconnect from the Couchbase cluster after you have finished working with it.
 	err = cluster.Close(nil)
 	if err != nil {
 		log.Fatal(err)

--- a/modules/devguide/examples/go/student-record/insert_courses/main.go
+++ b/modules/devguide/examples/go/student-record/insert_courses/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
 	"log"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
+	"github.com/sirupsen/logrus"
+
+	"student-record/internal"
 )
 
 func main() {
@@ -14,7 +16,7 @@ func main() {
 	password := "<<password>>"                  // Replace this with password from cluster access credentials
 
 	// Setup info level logging.
-	gocb.SetLogger(NewLogger(logrus.InfoLevel))
+	gocb.SetLogger(internal.NewLogger(logrus.InfoLevel))
 
 	options := gocb.ClusterOptions{
 		Authenticator: gocb.PasswordAuthenticator{

--- a/modules/devguide/examples/go/student-record/insert_student/main.go
+++ b/modules/devguide/examples/go/student-record/insert_student/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
 	"github.com/sirupsen/logrus"
+
+	"student-record/internal"
 )
 
 func main() {
@@ -15,9 +16,8 @@ func main() {
 	password := "<<password>>"                  // Replace this with password from cluster access credentials
 
 	// Setup info level logging.
-	gocb.SetLogger(NewLogger(logrus.InfoLevel))
+	gocb.SetLogger(internal.NewLogger(logrus.InfoLevel))
 
-	// Connecting to the cluster
 	options := gocb.ClusterOptions{
 		Authenticator: gocb.PasswordAuthenticator{
 			Username: username,
@@ -25,7 +25,6 @@ func main() {
 		},
 	}
 
-	// Use the pre-configured profile below to avoid latency issues with your connection.
 	if err := options.ApplyProfile(gocb.ClusterConfigProfileWanDevelopment); err != nil {
 		log.Fatal(err)
 	}
@@ -35,25 +34,30 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// The `cluster.Bucket` retrieves the bucket you set up for the student cluster.
 	bucket := cluster.Bucket("student-bucket")
-
-	// Forces the application to wait until the bucket is ready.
 	err = bucket.WaitUntilReady(10*time.Second, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// The `bucket.Scope` retrieves the `art-school-scope` from the bucket.
 	scope := bucket.Scope("art-school-scope")
-
-	// The `scope.Collection` retrieves the student collection from the scope.
 	studentRecords := scope.Collection("student-record-collection")
 
-	// A check to make sure the collection is connected and retrieved when you run the application.
-	fmt.Println("The name of this collection is", studentRecords.Name())
+	// Create and populate the student record.
+	hilary := map[string]interface{}{
+		"name":          "Hilary Smith",
+		"date-of-birth": "1980-12-21",
+	}
 
-	// Like with all database systems, it's good practice to disconnect from the Couchbase cluster after you have finished working with it.
+	// The `Upsert` function inserts or updates documents in a collection.
+	// The first parameter is a unique ID for the document, similar to a primary key used in a relational database system.
+	// If the `Upsert` call finds a document with a matching ID in the collection, it updates the document.
+	// If there is no matching ID, it creates a new document.
+	_, err = studentRecords.Upsert("000001", hilary, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	err = cluster.Close(nil)
 	if err != nil {
 		log.Fatal(err)

--- a/modules/devguide/examples/go/student-record/internal/logger.go
+++ b/modules/devguide/examples/go/student-record/internal/logger.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"os"

--- a/modules/hello-world/pages/student-record-developer-tutorial.adoc
+++ b/modules/hello-world/pages/student-record-developer-tutorial.adoc
@@ -294,53 +294,55 @@ Next, connect your Go SDK to your cluster.
 === Set Up Logging
 Before we connect to the cluster we want a way to see the output of the SDK and any errors that may occur.
 
-. In your `student-record` directory, create a new file called `logger.go`.
+. In your `student-record` directory, create a new directory `internal` containing a file called `logger.go`.
 +
 ....
 📂 ~ (your home directory)
   📂 student-record
     📃 go.mod
-    📃 logger.go ⬅ here!
+    📂 internal
+        📃 logger.go ⬅ here!
 ....
 +
-. Paste the following code block into your `logger.go` file:
+. Paste the following code block into your `internal/logger.go` file:
 +
 [source, go]
 ----
-include::devguide:example$go/student-record/logger.go[]
+include::devguide:example$go/student-record/internal/logger.go[]
 ----
-
 
 [#connect-to-the-cluster]
 === Connect the SDK to Your Cluster
 
 To connect to the cluster:
 
-. In your `student-record` directory, create a new file called `connect_student.go`.
+. In your `student-record` directory, create a new directory called `connect_student` containing a `main.go` file.
 +
 ....
 📂 ~ (your home directory)
   📂 student-record
     📃 go.mod
-    📃 logger.go
-    📃 connect_student.go ⬅ here!
+    📂 internal
+        📃 logger.go
+    📂 connect_student
+        📃 main.go ⬅ here!
 ....
 +
-. Paste the following code block into your `connect_student.go` file:
+. Paste the following code block into your `connect_student/main.go` file:
 +
 [source, go]
 ----
-include::devguide:example$go/student-record/connect_student.go[]
+include::devguide:example$go/student-record/connect_student/main.go[]
 ----
 
-. In the `connect_student.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
+. In the `connect_student/main.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
 +
 . Open a terminal window and navigate to your `student-record` directory.
 . Run the following command to check that the connection works:
 +
 [source, console]
 ----
-go run connect_student.go
+go run ./connect_student
 ----
 +
 If the connection is successful, the collection name outputs in the console log.
@@ -389,21 +391,21 @@ After connecting to the cluster, you can create a student record in the form of 
 
 To create a student record:
 
-. In your `student-record` directory, create a new file called `insert_student.go`.
-. Paste the following code block into your `insert_student.go` file:
+. In your `student-record` directory, create a new directory called `insert_student` containing a `main.go` file.
+. Paste the following code block into your `insert_student/main.go` file:
 +
 [source, go]
 ----
-include::devguide:example$go/student-record/insert_student.go[]
+include::devguide:example$go/student-record/insert_student/main.go[]
 ----
 +
-. In the `insert_student.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
+. In the `insert_student/main.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
 . Open a terminal window and navigate to your `student-record` directory.
 . Run the following command to insert the student record into the collection:
 +
 [source, console]
 ----
-go run insert_student.go
+go run ./insert_student
 ----
 +
 . From the Capella UI, go to your student cluster and check the `student-record-collection` for the new student record you just added:
@@ -419,21 +421,21 @@ image::new-student-record.png[alt="Student added to the student-record-collectio
 Creating course records is similar to creating student records.
 To create course records:
 
-. In your `student-record` directory, create a new file called `insert_courses.go`.
-. Paste the following code block into your `insert_courses.go` file:
+. In your `student-record` directory, create a new directory called `insert_courses` containing a `main.go` file.
+. Paste the following code block into your `insert_courses/main.go` file:
 +
 [source, go]
 ----
-include::devguide:example$go/student-record/insert_courses.go[]
+include::devguide:example$go/student-record/insert_courses/main.go[]
 ----
 +
-. In the `insert_courses.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
+. In the `insert_courses/main.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
 . Open a terminal window and navigate to your `student-record` directory.
 . Run the following command to insert the course records into the collection:
 +
 [source, console]
 ----
-go run insert_courses.go
+go run ./insert_courses
 ----
 +
 . From the Capella UI, go to your student cluster and check the `course-record-collection` for the new course records you just added.
@@ -605,21 +607,21 @@ You can use the SDK to retrieve all course records at once, or narrow your searc
 
 To retrieve all of your course records using the Go SDK:
 
-. In your `student-record` directory, create a new file called `art_school_retriever_all.go`.
-. Paste the following code block into your `art_school_retriever_all.go` file:
+. In your `student-record` directory, create a new directory called `art_school_retriever_all` containing a `main.go` file.
+. Paste the following code block into your `art_school_retriever_all/main.go` file:
 +
 [source, go]
 ----
-include::devguide:example$go/student-record/art_school_retriever_all.go[]
+include::devguide:example$go/student-record/art_school_retriever_all/main.go[]
 ----
 +
-. In the `art_school_retriever_all.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
+. In the `art_school_retriever_all/main.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
 . Open a terminal window and navigate to your `student-record` directory.
 . Run the following command to retrieve all course records:
 +
 [source, console]
 ----
-go run art_school_retriever_all.go
+go run ./art_school_retriever_all
 ----
 +
 If the retrieval is successful, the course information outputs in the console log.
@@ -651,21 +653,21 @@ time="2026-03-31T12:02:59+01:00" level=info msg="Agent close complete"
 You can set parameters in your code to narrow your search down further.
 To retrieve only courses with less than 200 `credit-points` using the Go SDK:
 
-. In your `student-record` directory, create a new file called `art_school_retriever.go`.
-. Paste the following code block into your `art_school_retriever.go` file:
+. In your `student-record` directory, create a new directory called `art_school_retriever` containing a `main.go` file.
+. Paste the following code block into your `art_school_retriever/main.go` file:
 +
 [source, go]
 ----
-include::devguide:example$go/student-record/art_school_retriever.go[]
+include::devguide:example$go/student-record/art_school_retriever/main.go[]
 ----
 +
-. In the `art_school_retriever.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
+. In the `art_school_retriever/main.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
 . Open a terminal window and navigate to your `student-record` directory.
 . Run the following command to retrieve course records with parameters:
 +
 [source, console]
 ----
-go run art_school_retriever.go
+go run ./art_school_retriever
 ----
 +
 If the retrieval is successful, the course information with your parameters outputs in the console log.
@@ -703,24 +705,24 @@ After retrieving student and course records, you can add enrollment details to t
 
 To add enrollment details to a student record:
 
-. In your `student-record` directory, create a new file called `add_enrollments.go`.
-. Paste the following code block into your `add_enrollments.go` file:
+. In your `student-record` directory, create a new directory called `add_enrollments` containing a `main.go` file.
+. Paste the following code block into your `add_enrollments/main.go` file:
 +
 [source, go]
 ----
-include::devguide:example$go/student-record/add_enrollments.go[]
+include::devguide:example$go/student-record/add_enrollments/main.go[]
 ----
 +
 NOTE: Because this is a tutorial, you do not need to add an error check to make sure that your collection has returned an item.
 In a live application, error checks must be made to prevent errors and keep the application running.
 +
-. In the `add_enrollments.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
+. In the `add_enrollments/main.go` file, replace the `\<<connection-string>>`, `\<<username>>`, and `\<<password>>` placeholders with the connection string, username, and password that you noted when configuring the cluster connection.
 . Open a terminal window and navigate to your `student-record` directory.
 . Run the following command to add the enrollment details to the student record:
 +
 [source, console]
 ----
-go run add_enrollments.go
+go run ./add_enrollments
 ----
 +
 . From the Capella UI, go to your student cluster.


### PR DESCRIPTION
The student-record example we have in the docs folllows an unconventional project structure, with more than one main methods per directory. The instructions do say to run them via go run <file>.go, which could work, but does not, as each example file utilizes the logger that’s defined in a separate file:
```
❯ go run connect_student.go
# command-line-arguments
./connect_student.go:18:17: undefined: NewLogger
```
 

To avoid this, we should follow a more conventional Go project structure with one main function per directory, and update the tutorial accordingly.

Instead of the current:
```
📂 ~ (your home directory)
  📂 student-record
    📃 go.mod
    📃 logger.go
    📃 connect_student.go
    📃 insert_courses.go
    ...
```

It should be:
```
📂 ~ (your home directory)
  📂 student-record
    📃 go.mod
    📂 internal
        📃 logger.go
    📂 connect_student
        📃 main.go
    📂 insert_courses
        📃 main.go
    ...
```