### PR TITLE
GOCBC-1829: Add workflow_dispatch for Examples workflow & only trigger if specific files change

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,39 +2,65 @@ name: Examples
 
 on:
   push:
-    branches:
+    branches: &trigger-branches
       - release/2.*
 
+    paths: &trigger-paths
+      - modules/devguide/examples/go/**
+      - .github/workflows/examples.yml
+      - antora.yml
+      - modules/project-docs/pages/sdk-release-notes.adoc
+
   pull_request:
-    branches:
-      - release/2.*
+    branches: *trigger-branches
+    paths: *trigger-paths
+
+  workflow_dispatch:
+    inputs:
+      sdk-version:
+        description: 'gocb version to build with (e.g. v2.12.3, master, c84becd). If not set, will use the version specified in go.mod.'
+        required: false
+        default: ''
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./modules/devguide/examples/go
+
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
-          go-version-file: ./modules/devguide/examples/go/go.mod
+          go-version: stable
+          cache-dependency-path: ./modules/devguide/examples/go/go.mod
 
-      - working-directory: ./modules/devguide/examples/go
-        run: |
-          make lint
+      - if: inputs.sdk-version != ''
+        run: make set-sdk-version SDK_VERSION=${{ inputs.sdk-version }}
 
+      - run: make lint
 
   build:
     name: Build
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./modules/devguide/examples/go
+
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
-          go-version-file: ./modules/devguide/examples/go/go.mod
+          go-version: stable
+          cache-dependency-path: ./modules/devguide/examples/go/go.mod
 
-      - working-directory: ./modules/devguide/examples/go
-        run: |
-          make build
+      - if: inputs.sdk-version != ''
+        run: make set-sdk-version SDK_VERSION=${{ inputs.sdk-version }}
+
+      - run: make build

--- a/modules/devguide/examples/go/Makefile
+++ b/modules/devguide/examples/go/Makefile
@@ -6,6 +6,11 @@ build-examples:
 
 build: build-student-record build-examples
 
+set-sdk-version:
+	@[ -n "$(SDK_VERSION)" ] || (echo "SDK_VERSION is required (e.g. v2.12.3, master, c84becd)" >&2; exit 1)
+	go get github.com/couchbase/gocb/v2@$(SDK_VERSION)
+	cd student-record && go get github.com/couchbase/gocb/v2@$(SDK_VERSION)
+
 lint:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8
 	golangci-lint run -v


### PR DESCRIPTION
## Changes

* Add `workflow_dispatch` trigger taking the SDK version as input
* Update the workflow to set the specific gocb version, if one is provided
* Use the latest stable Golang version in the workflow, to avoid any issues when the gocb specified in the workflow dispatch is not compatible with the Golang version in the committed go.mod
* Updates the push/pull_request triggers so they are only triggered when specific files change (Examples source, release notes, antora.yml, the workflow file itself)