### PR TITLE
GOCBC-1829: Fix workflow dispatch examples workflow triggers

### DIFF
--- a/modules/devguide/examples/go/Makefile
+++ b/modules/devguide/examples/go/Makefile
@@ -8,8 +8,13 @@ build: build-student-record build-examples
 
 set-sdk-version:
 	@[ -n "$(SDK_VERSION)" ] || (echo "SDK_VERSION is required (e.g. v2.12.3, master, c84becd)" >&2; exit 1)
+	go mod edit -droprequire github.com/couchbase/gocbcore/v10
 	go get github.com/couchbase/gocb/v2@$(SDK_VERSION)
-	cd student-record && go get github.com/couchbase/gocb/v2@$(SDK_VERSION)
+	go mod tidy
+	cd student-record && \
+		go mod edit -droprequire github.com/couchbase/gocbcore/v10 && \
+		go get github.com/couchbase/gocb/v2@$(SDK_VERSION) && \
+		go mod tidy
 
 lint:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8


### PR DESCRIPTION
Remove the gocbcore dependency before changing the gocb version to ensure that the right version of gocbcore is pulled.